### PR TITLE
fix email validator

### DIFF
--- a/src/validators.js
+++ b/src/validators.js
@@ -36,7 +36,7 @@ exports.alphanum = function (value) {
 };
 
 exports.email = function (value) {
-    return /^([a-z0-9!#$%&'*+\/=?^_`{|}~.-]+@[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*)?$/i.test(value || 'a@a.aa');
+    return /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i.test(value || 'a@a.aa');
 };
 
 exports.url = function (value) {


### PR DESCRIPTION
The current regex would validate an email like "a@a" or "a@a.a" while the update will only validate if as "a@a.aa". It as well add support for unicode characters.
